### PR TITLE
Fixed missing translations on get involved map

### DIFF
--- a/src/app/get-involved/get-involved.component.ts
+++ b/src/app/get-involved/get-involved.component.ts
@@ -1,10 +1,11 @@
 import { Component, OnInit, OnDestroy, Input } from '@angular/core';
 
 import { map } from 'rxjs/operators';
-import { Subscription } from 'rxjs';
+import { Subscription, combineLatest } from 'rxjs';
 
 import { CountrySupportersService } from './country-supporters.service';
 import { GeoChartConfig } from './chart-configuration';
+import { TranslateService } from '@ngx-translate/core';
 
 @Component({
   selector: 'gp-get-involved',
@@ -19,13 +20,18 @@ export class GetInvolvedComponent implements OnInit, OnDestroy {
   data;
   chart;
 
-  constructor(private countrySupportersService: CountrySupportersService) { }
+  constructor(private countrySupportersService: CountrySupportersService,
+    private translateService: TranslateService) { }
 
   ngOnInit() {
-    this.subscription = this.countrySupportersService.getAll()
+    this.subscription = combineLatest(
+      this.countrySupportersService.getAll(),
+      this.translateService.get('get-involved.people-involved')
+    )
     .pipe(
-      map((countrySupporters) =>
-      countrySupporters.map(({count, country}) => [country, count, this.generateHtmlTooltip(country, count)])
+      map(([countrySupporters, peopleInvolvedTranslation]) =>
+        countrySupporters.map(({count, country}) =>
+          [country, count, this.generateHtmlTooltip(country, count, peopleInvolvedTranslation)])
       ))
       .subscribe((supporters) => {
         this.isLoading = false;
@@ -40,10 +46,10 @@ export class GetInvolvedComponent implements OnInit, OnDestroy {
     }
   }
 
-  generateHtmlTooltip(countryName, countryCount) {
+  generateHtmlTooltip(countryName: string, countryCount: number, peopleInvolvedTranslation: string) {
     return `<div>
       <p style="font-size: 15px;"><b>${countryName}</b></p>
-      <p>People Involved<br/> ${countryCount}</p>
+      <p>${peopleInvolvedTranslation}<br/> ${countryCount}</p>
     </div>`;
   }
 }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -36,6 +36,7 @@
   },
   "get-involved": {
     "title": "Get Involved",
+    "people-involved": "People Involved",
     "subscription": {
       "title": "Subscribe",
       "intro": "I want to get involved because... Aliquam ac viverra sem. Nunc dictum diam arcu. Mauris a bibendum turpis, a fermentum ligula. Morbi eu dolor ac elit accumsan consequat. Sed feugiat dapibus blandit. Nunc posuere tempus neque, et pulvinar nunc fermentum vitae. Etiam at ex rutrum, interdum metus eu, venenatis purus. Sed viverra sed nibh eget pharetra.",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -36,6 +36,7 @@
   },
   "get-involved": {
     "title": "Involúcrate",
+    "people-involved": "Personas Involucradas",
     "subscription": {
       "title": "Subscribirme",
       "intro": "Quiero subscribirme porque... Aliquam ac viverra sem. Nunc dictum diam arcu. Mauris a bibendum turpis, a fermentum ligula. Morbi eu dolor ac elit accumsan consequat. Sed feugiat dapibus blandit. Nunc posuere tempus neque, et pulvinar nunc fermentum vitae. Etiam at ex rutrum, interdum metus eu, venenatis purus. Sed viverra sed nibh eget pharetra.",


### PR DESCRIPTION
Fixed translation missing on get involved map tooltip.

<blockquote class="trello-card"><a href="https://trello.com/c/Li0TXVYL/6-homeas-a-normal-user-i-want-to-see-a-world-map-in-order-to-see-how-many-people-are-supporting-the-community">[Home]As a normal user, I want to see a world map in order to see how many people are supporting the community</a></blockquote>